### PR TITLE
bugfix: retrieving cookies when adding a new download

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ chrome-aria2-integration
 
 aria2 integration extension for Chrome
 
-Web Store: http://chrome.google.com/webstore/detail/aria2c-integration/edcakfpjaobkpdfpicldlccdffkhpbfk
+Web Store: https://chrome.google.com/webstore/detail/aria2c-integration/cnkefpcjiolhnmhfpjbjpidgncnajlmf
 
 This extension captures new download tasks and sends them to aria2 automatically, as per capturing rules you set (file size, file type, site whitelist, site blacklist)
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,9 +18,12 @@
   "permissions": [
     "contextMenus",
     "activeTab",
+    "tabs",
     "downloads",
     "notifications",
-    "storage"
+    "storage",
+    "cookies",
+    "*://*/"
   ],
   "browser_action": {
    "default_icon": {


### PR DESCRIPTION
The code to retrieve the cookies for the download didn't work anymore, so I updated it to use _chrome.cookies.getAll_

The auto capture download function threw some errors, too, while I tested it, so I updated this as well. 

By the way the version of the extension in the chrome store is 1.7.1 while this is still 1.7.0.
